### PR TITLE
Boolean conversion of string for cells doesnt work

### DIFF
--- a/lib/xlsx_writer/cell.rb
+++ b/lib/xlsx_writer/cell.rb
@@ -110,7 +110,7 @@ class XlsxWriter
             (value.to_date - JAN_1_1900.to_date).to_i
           end
         when :Boolean
-          value ? 1 : 0
+          value.to_s.downcase == 'true' ? 1 : 0
         else
           value.fast_xs
         end


### PR DESCRIPTION
When using strings `true` or `false`, Cell.escape will return `1` for both since string `true` and `false` are identified as boolean type.
