### PR TITLE
Bugfix for TRUE_FALSE_PATTERN and LibreOffice/Numbers

### DIFF
--- a/lib/xlsx_writer/cell.rb
+++ b/lib/xlsx_writer/cell.rb
@@ -140,7 +140,7 @@ class XlsxWriter
     DATE_LENGTH = 'YYYY-MM-DD'.length
     BOOLEAN_LENGTH = 'FALSE'.length + 1
     JAN_1_1900 = Time.parse('1899-12-30 00:00:00 UTC')
-    TRUE_FALSE_PATTERN = %r{^true|false$}i
+    TRUE_FALSE_PATTERN = %r{^(true|false)$}i
     BIG_DECIMAL = defined?(BigDecimal) ? BigDecimal : Struct.new
 
     STYLE_NUMBER = {

--- a/lib/xlsx_writer/sheet.rb
+++ b/lib/xlsx_writer/sheet.rb
@@ -97,9 +97,13 @@ EOS
     def rid
       "rId#{ndx + 1}"
     end
+
+    def filename
+      "sheet#{ndx}.xml"
+    end
     
     def relative_path
-      "xl/worksheets/sheet#{ndx}.xml"
+      "xl/worksheets/#{filename}"
     end
     
     def absolute_path

--- a/lib/xlsx_writer/xml/workbook_rels.erb
+++ b/lib/xlsx_writer/xml/workbook_rels.erb
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-  <Relationship Id="rId0" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedstrings.xml"/>
-  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="/xl/styles.xml"/>
+  <Relationship Id="rId0" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
   <% document.sheets.each do |sheet| %>
-  <Relationship Id="<%= sheet.rid %>" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="<%= sheet.absolute_path %>"/>
+  <Relationship Id="<%= sheet.rid %>" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/<%= sheet.filename %>"/>
   <% end %>
 </Relationships>


### PR DESCRIPTION
Two small bug fixes. One results in strings like "True, this is not boolean" and "This is false" being interpreted as booleans. The other prevents the .xlsx files from opening in Numbers and LibreOffice.
