### PR TITLE
Fix for workbook rels file paths and case

### DIFF
--- a/lib/xlsx_writer/sheet.rb
+++ b/lib/xlsx_writer/sheet.rb
@@ -97,9 +97,13 @@ EOS
     def rid
       "rId#{ndx + 1}"
     end
+
+    def filename
+      "sheet#{ndx}.xml"
+    end
     
     def relative_path
-      "xl/worksheets/sheet#{ndx}.xml"
+      "xl/worksheets/#{filename}"
     end
     
     def absolute_path

--- a/lib/xlsx_writer/xml/workbook_rels.erb
+++ b/lib/xlsx_writer/xml/workbook_rels.erb
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-  <Relationship Id="rId0" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedstrings.xml"/>
-  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="/xl/styles.xml"/>
+  <Relationship Id="rId0" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
   <% document.sheets.each do |sheet| %>
-  <Relationship Id="<%= sheet.rid %>" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="<%= sheet.absolute_path %>"/>
+  <Relationship Id="<%= sheet.rid %>" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/<%= sheet.filename %>"/>
   <% end %>
 </Relationships>


### PR DESCRIPTION
Workbook relationship target paths were being generated with
relative paths including "xl/", Numbers and LibreOffice didn't like
this. The sharedStrings target was all lower-case, they also didn't like
this.
